### PR TITLE
Clarify that the `Softmax` derivative is good-enough

### DIFF
--- a/Assets/Scripts/Neural Network/Activation/Activation.cs
+++ b/Assets/Scripts/Neural Network/Activation/Activation.cs
@@ -126,6 +126,13 @@ public readonly struct Activation
 			return res;
 		}
 
+		// Much like stochastic gradient descent's quick, not-so-perfect steps downhill
+		// using mini-batches, this derivative serves as a good-enough approximation. It's
+		// simpler to calculate and we can keep our interface consistent with the other
+		// single-input activation functions above (though it won't pass gradient checks). A
+		// complete derivative for the Softmax function involves computing a Jacobian matrix
+		// which finds partial derivative of the activation function with respect to all of
+		// the inputs of each node in the layer.
 		public double Derivative(double[] inputs, int index)
 		{
 			double expSum = 0;


### PR DESCRIPTION
First, thank you so much for this amazing resource and video series! 🙇 Your videos are a gold-standard to understand concepts and polished end-products to impress everyone 🌠

While following along and writing my own implementation in Zig, I added some [gradient check tests](https://cs231n.github.io/neural-networks-3/#gradcheck) to ensure my backpropagation code/math was correct and saw that they were failing whenever I used `Softmax`. I banged my head against this for a long-while and even compared the network outputs to this implementation only to find it the exact same.

Finally after some external help, I realized the difference between single-input activation functions like `Sigmoid`, `TanH`, `ReLU` and the multi-input activation functions like `Softmax` which require more work to find the full derivative. I wrote some [notes on the difference](https://github.com/MadLittleMods/zig-neural-networks/blob/main/dev-notes.md#activation-functions) or perhaps the [source](https://github.com/MadLittleMods/zig-neural-networks/blob/744c82d4be019984a272ec718d04a40f0f249470/src/activation_functions.zig#L147-L277) [code](https://github.com/MadLittleMods/zig-neural-networks/blob/744c82d4be019984a272ec718d04a40f0f249470/src/layers/ActivationLayer.zig#L56-L217) I ended up with is easier to understand.

Just wanted to add a note to the code here so others don't hit the same pitfall as hard.

It's really interesting how the "good-enough" derivative of `Softmax` using only the diagonal elements from the Jacobian matrix, empirically, still works so well for the neural network to converge. The best way I was able to understand this and relate this to a concept that has more research/documentation is stochastic gradient descent which trains with mini-batches to make quick, imperfect but good-enough steps down the cost gradient. 